### PR TITLE
Log error messages for invalid Lichess token + Testing

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,14 @@ jacocoTestReport {
         xml.enabled true
         html.enabled true
     }
+  
+    afterEvaluate {
+        classDirectories = files(classDirectories.files.collect {
+            fileTree(dir: it, exclude: [
+                'chess/App*'
+            ])
+        })
+    }
 }
 
 repositories {

--- a/src/main/java/chess/connection/LichessAPI.java
+++ b/src/main/java/chess/connection/LichessAPI.java
@@ -83,7 +83,6 @@ public class LichessAPI {
         }
 
         return profile;
-
     }
 
     /**

--- a/src/main/java/chess/connection/LichessAPI.java
+++ b/src/main/java/chess/connection/LichessAPI.java
@@ -97,7 +97,14 @@ public class LichessAPI {
                 .get("https://lichess.org/api/stream/event")
                 .setHeaders(headers)
                 .connect();
-
+        
+        if (eventStream.getHTTPStatus() != 200) {
+            logger.logError("Lichess returned Error code " + eventStream.getHTTPStatus() 
+                    + ": your Lichess token might be invalid.");
+            
+            return;
+        }
+        
         handleEventLoop(eventStream.getIterator());
 
         try {
@@ -148,7 +155,14 @@ public class LichessAPI {
                 .get("https://lichess.org/api/bot/game/stream/" + gameId)
                 .setHeaders(headers)
                 .connect();
-
+        
+        if (gameStream.getHTTPStatus() != 200) {
+            logger.logError("Lichess returned Error code " + gameStream.getHTTPStatus() 
+                    + ": your Lichess token might be invalid.");
+            
+            return;
+        }
+        
         playGame(gameStream.getIterator());
 
         try {

--- a/src/main/java/chess/connection/LichessAPI.java
+++ b/src/main/java/chess/connection/LichessAPI.java
@@ -48,7 +48,7 @@ public class LichessAPI {
         // Add token to HTTP headers
         headers.put("Authorization", "Bearer " + token);
     }
-
+            
     /**
      * Get Lichess account information
      *
@@ -60,7 +60,14 @@ public class LichessAPI {
                 .get("https://lichess.org/api/account")
                 .setHeaders(headers)
                 .connect();
-
+        
+        if (stream.getHTTPStatus() != 200) {
+            logger.logError("Lichess returned Error code " + stream.getHTTPStatus() 
+                    + ": your Lichess token might be invalid.");
+            
+            return null;
+        }
+        
         json = stream.toString();
 
         try {

--- a/src/main/java/logging/Logger.java
+++ b/src/main/java/logging/Logger.java
@@ -9,6 +9,7 @@ import java.io.FileWriter;
 import java.io.IOException;
 // import java.nio.file.Path;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.logging.Level;
 
 /**
@@ -27,7 +28,10 @@ public class Logger {
     
     private boolean useStdOut;
     private boolean useLogFile;
+    private boolean useMemory;
     private String filePath;
+    
+    public ArrayList<String> inMemoryLog;
     
     /**
      * Default constructor, will not log until logging features are manually enabled
@@ -35,6 +39,9 @@ public class Logger {
     public Logger() {
         useStdOut = false;
         useLogFile = false;
+        useMemory = false;
+        
+        this.inMemoryLog = new ArrayList<>();
         filePath = "./log.txt";
     }
     
@@ -44,6 +51,16 @@ public class Logger {
      */
     public Logger useStdOut() {
         this.useStdOut = true;
+        
+        return this;
+    }
+    
+    /**
+     * Turn on logging to a text file
+     * @return 
+     */
+    public Logger useMemory() {
+        this.useMemory = true;
         
         return this;
     }
@@ -81,6 +98,11 @@ public class Logger {
             System.out.println(messageWithDate);
         }
         
+        if (useMemory) {
+            messageWithDate = LocalDateTime.now().toString() + " MESSAGE: " + message;
+            inMemoryLog.add(messageWithDate);
+        }
+        
         if (useLogFile) {
             messageWithDate = LocalDateTime.now().toString() + " MESSAGE: " + message;
             
@@ -111,6 +133,11 @@ public class Logger {
         if (useStdOut) {
             messageWithDate = LocalDateTime.now().toString() + textInRed(" ERROR: ") + message;
             System.out.println(messageWithDate);
+        }
+        
+        if (useMemory) {
+            messageWithDate = LocalDateTime.now().toString() + " ERROR: " + message;
+            inMemoryLog.add(messageWithDate);
         }
         
         if (useLogFile) {

--- a/src/test/java/chess/connection/LichessApiTest.java
+++ b/src/test/java/chess/connection/LichessApiTest.java
@@ -16,6 +16,8 @@ import java.io.InputStreamReader;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Iterator;
+import java.util.function.Predicate;
+import java.util.stream.Stream;
 import logging.Logger;
 import org.junit.After;
 import org.junit.AfterClass;
@@ -45,7 +47,7 @@ public class LichessApiTest {
     @Before
     public void setUp() {
         this.bot = new TestBot("");
-        this.logger = new Logger().useLogFile();
+        this.logger = new Logger().useMemory();
         this.httpFactory = new MockHTTPIOFactory();
         this.api = new LichessAPI(bot, logger, httpFactory);
     }
@@ -186,5 +188,30 @@ public class LichessApiTest {
         this.api = new LichessAPI(new MockBot(Arrays.asList("d7d5", "c7c5", "b7b5", "d8d7", "e8d7")), this.logger, this.httpFactory);
         this.api.beginEventLoop();
 
+    }
+    
+    @Test
+    public void lichessAPILogsAnErrorOnHTTPErrorCode() {
+        MockHTTPIO mockStream = new MockHTTPIO();
+        
+        mockStream.setStatusCode(401);
+        
+        this.httpFactory.addMockHTTPIOToQueue(mockStream);
+        
+        this.api.getAccount();
+        
+        assert(this.logger.inMemoryLog.size() > 0);
+    }
+    
+    public boolean anyMatch(Iterator<String> iterator, Predicate<String> pred) {
+        while (iterator.hasNext()) {
+            String value = iterator.next();
+            
+            if (pred.test(value)) {
+                return true;
+            }
+        }
+        
+        return false;
     }
 }

--- a/src/test/java/chess/connection/MockHTTPIO.java
+++ b/src/test/java/chess/connection/MockHTTPIO.java
@@ -17,6 +17,11 @@ public class MockHTTPIO implements HTTPIO {
     
     public Map<String, String> headers;
     public Iterator<String> output;
+    public int statusCode = 200;
+    
+    public void setStatusCode(int statusCode) {
+        this.statusCode = statusCode;
+    }
     
     public void setOutput(Iterator<String> output) {
         this.output = output;
@@ -54,7 +59,7 @@ public class MockHTTPIO implements HTTPIO {
 
     @Override
     public int getHTTPStatus() {
-        return 200;
+        return this.statusCode;
     }
 
     @Override

--- a/src/test/java/chess/connection/NullBot.java
+++ b/src/test/java/chess/connection/NullBot.java
@@ -1,0 +1,23 @@
+package chess.connection;
+
+import chess.bot.ChessBot;
+import chess.engine.GameState;
+import java.util.Iterator;
+import java.util.List;
+
+public class NullBot implements ChessBot {
+
+    public NullBot() {
+    }
+
+    @Override
+    public String nextMove(GameState gamestate) {
+        return null;
+    }
+
+    @Override
+    public String getToken() {
+        return "";
+    }
+
+}

--- a/src/test/java/logging/LoggerTest.java
+++ b/src/test/java/logging/LoggerTest.java
@@ -116,4 +116,13 @@ public class LoggerTest {
             }
         }
     }
+    
+    @Test
+    public void writingToInMemoryLogWorks() {
+        logger.useMemory();
+        
+        logger.logMessage("Hello, World!");
+        
+        assert(logger.inMemoryLog.size() > 0);
+    }
 }


### PR DESCRIPTION
This PR introduces more logging for LichessAPI in error cases (such as invalid Lichess Token).
Along with that, this PR introduces more JUnit tests for LichessAPI to cover the error states and a few other branches. I also excluded App.java from testing, since it is fundamentally untestable.